### PR TITLE
Fixes the laravel-news submission link

### DIFF
--- a/database/seeders/TargetSeeder.php
+++ b/database/seeders/TargetSeeder.php
@@ -10,7 +10,7 @@ class TargetSeeder extends Seeder
     protected $targets = [
         [
             'name' => 'Laravel News',
-            'url' => 'https://laravel-news.com/links/create',
+            'url' => 'https://laravel-news.com/links/submit',
         ],
         [
             'name' => 'Freek.dev',


### PR DESCRIPTION
## Intent
When accessing following links from the postit site send to 404 page.
![image](https://github.com/tighten/postit/assets/9332696/72504d6d-150e-4046-afba-dc93db51a271)

## Highlights
- updates the laravel-news submission link